### PR TITLE
Dev

### DIFF
--- a/resources/views/frontend/event.blade.php
+++ b/resources/views/frontend/event.blade.php
@@ -81,7 +81,7 @@
                                         <div data-scroll data-scroll-speed="0.5">
                                             <div class="speaker">
                                                 <figure><img
-                                                        {{-- src="{{ $organizer->img ? Storage::disk('s3')->url($organizer->img) : '' }}" --}}
+                                                        src="{{ $organizer->img ? Storage::disk('s3')->url($organizer->img) : '' }}"
                                                         alt="Image">
                                                     <figcaption>
                                                         <ul>


### PR DESCRIPTION
This pull request includes changes to the `resources/views/frontend/event.blade.php` file to improve the handling of image URLs and comments out an unused image source.

Changes to image handling:

* [`resources/views/frontend/event.blade.php`](diffhunk://#diff-86a3b8026b751b85bbd9e60eec8d29ac22bb1d8d8b551a5a6382078f1dca53f4L26-R26): Fixed formatting for the `img` tag to ensure proper URL retrieval from the S3 storage for the event image.
* [`resources/views/frontend/event.blade.php`](diffhunk://#diff-86a3b8026b751b85bbd9e60eec8d29ac22bb1d8d8b551a5a6382078f1dca53f4L85-R84): Commented out the `img` tag for the organizer's image to prevent unnecessary loading of the image from S3 storage.