### PR TITLE
added transaction req

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -61,8 +61,7 @@ class RegisterController extends Controller
             'usn' => ['required', 'max:255', 'unique:users'],
             'phone' => ['required', 'max:255'],
             'college_name' => ['required'],
-            'transaction_id' => ['nullable', 'unique:users'],
-
+            'transaction_id' => ['required', 'unique:users'],
             'payment_screenshot' => ['required']
         ]);
     }


### PR DESCRIPTION
This pull request modifies the validation rules in the `RegisterController` to enforce stricter requirements for the `transaction_id` field. The most important change is making the `transaction_id` field mandatory during registration.

Validation rule update:

* [`app/Http/Controllers/Auth/RegisterController.php`](diffhunk://#diff-6bf28759467ab9d7b7bdf08ccb156d3c4096c034096f086eca89a0cb1d2316c8L64-R64): Changed the `transaction_id` field's validation rule from `nullable` to `required`, ensuring it is now a mandatory field.