### PR TITLE
done

### DIFF
--- a/resources/views/app/users/index.blade.php
+++ b/resources/views/app/users/index.blade.php
@@ -63,9 +63,9 @@
                             <th class="text-left">
                                 @lang('crud.users.inputs.pass_type')
                             </th>
-                            <th class="text-left">
+                            {{-- <th class="text-left">
                                 @lang('crud.users.inputs.usn')
-                            </th>
+                            </th> --}}
                             {{-- <th class="text-left">
                                 @lang('crud.users.inputs.uid')
                             </th> --}}
@@ -98,7 +98,7 @@
                             <td>{{ $user->email ?? '-' }}</td>
                             <td>{{ $user->phone ?? '-' }}</td>
                             <td>{{ $user->pass_type ?? '-' }}</td>
-                            <td>{{ $user->usn ?? '-' }}</td>
+                            {{-- <td>{{ $user->usn ?? '-' }}</td> --}}
                             {{-- <td>{{ $user->uid ?? '-' }}</td> --}}
                             <td>{{ $user->transaction_id ?? '-' }}</td>
                             <td>{{ $user->college_name ?? '-' }}</td>


### PR DESCRIPTION
This pull request includes changes to the `resources/views/app/users/index.blade.php` file to temporarily hide the `usn` and `uid` columns from both the table headers and the table rows. These changes appear to be for debugging or simplifying the UI by commenting out unused or unnecessary fields.

Changes to the user table:

* Commented out the `usn` column in the table header, hiding it from the user interface. (`resources/views/app/users/index.blade.php`, [resources/views/app/users/index.blade.phpL66-R68](diffhunk://#diff-358adca0cc10eec13b3a4b8321f74bd2a8f34c806697193962a7bdaafc4f6357L66-R68))
* Commented out the `usn` column in the table rows, ensuring the corresponding data is not displayed. (`resources/views/app/users/index.blade.php`, [resources/views/app/users/index.blade.phpL101-R101](diffhunk://#diff-358adca0cc10eec13b3a4b8321f74bd2a8f34c806697193962a7bdaafc4f6357L101-R101))