### PR TITLE
done

### DIFF
--- a/app/Http/Controllers/ConcertEntryController.php
+++ b/app/Http/Controllers/ConcertEntryController.php
@@ -128,8 +128,14 @@ class ConcertEntryController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id)
+    public function destroy(Request $request, ConcertEntry $concert_entry)
     {
-        //
+        $this->authorize('delete', $concert_entry);
+
+        $concert_entry->delete();
+
+        return redirect()
+            ->route('concert-entries.index')
+            ->withSuccess(__('crud.common.removed'));
     }
 }


### PR DESCRIPTION
This pull request updates the `destroy` method in the `ConcertEntryController` to include authorization and improve functionality.

### Authorization and functionality improvements:
* [`app/Http/Controllers/ConcertEntryController.php`](diffhunk://#diff-ffaa713cd84017b093d27b70b97e227b331b2c2cf73eb82dcff560907848b0faL131-R139): Updated the `destroy` method to accept a `Request` and `ConcertEntry` object instead of just an `id`. Added authorization using `$this->authorize('delete', $concert_entry)`, deleted the specified concert entry, and redirected to the `concert-entries.index` route with a success message.